### PR TITLE
feat:+1: : Add Marked and Marked-Aozora libraries for Markdown parsing and update Paragraph component to render parsed text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@astrojs/tailwind": "^5.1.2",
         "astro": "^4.16.7",
         "dotenv": "^16.4.5",
+        "marked": "^15.0.0",
+        "marked-aozora": "^1.2.2",
         "microcms-js-sdk": "^3.1.2",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3"
@@ -5863,6 +5865,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.0.tgz",
+      "integrity": "sha512-0mouKmBROJv/WSHJBPZZyYofUgawMChnD5je/g+aOBXsHDjb/IsnTQj7mnhQZu+qPJmRQ0ecX3mLGEUm3BgwYA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-aozora": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/marked-aozora/-/marked-aozora-1.2.2.tgz",
+      "integrity": "sha512-dFVIKDAS9YnpThZudPdhZj93fXDbkqdSTfDeVP5NZhX/KuIIMsE2uGFb3qK6M3jq61chG1guwzQwWYjBhUHq5g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "marked": "^14.1.3"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@astrojs/tailwind": "^5.1.2",
     "astro": "^4.16.7",
     "dotenv": "^16.4.5",
+    "marked": "^15.0.0",
+    "marked-aozora": "^1.2.2",
     "microcms-js-sdk": "^3.1.2",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"

--- a/src/components/main/element/paragraph.astro
+++ b/src/components/main/element/paragraph.astro
@@ -1,0 +1,19 @@
+---
+// 本文を構成する要素のうち、段落部分を描画するコンポーネント
+
+import type { ContentParagraphElement } from "@lib/contentElements";
+import { inlineMarked } from "@lib/inlineMarked";
+
+interface Props {
+    paragraph: ContentParagraphElement;
+}
+
+const { paragraph } = Astro.props;
+const paratext = await inlineMarked(paragraph.text);
+console.log(paratext);
+---
+
+<div>
+    {/* 段落の頭にて1文字開けるため、先頭に全角スペースを挿入 */}
+    <p set:html={"　" + paratext} />
+</div>

--- a/src/lib/contentElements.ts
+++ b/src/lib/contentElements.ts
@@ -12,8 +12,8 @@ export type ContentHeadlineElement = {
     readonly level: "中" | "小" | "超小";
 };
 
-// インラインテキスト
-export type ContentPalagraphElement = {
+// パラグラフ
+export type ContentParagraphElement = {
     // フィールドID
     readonly fieldId: "paragraph";
 
@@ -22,4 +22,4 @@ export type ContentPalagraphElement = {
 };
 
 // コンテンツ要素
-export type ContentElement = ContentHeadlineElement | ContentPalagraphElement;
+export type ContentElement = ContentHeadlineElement | ContentParagraphElement;

--- a/src/lib/inlineMarked.ts
+++ b/src/lib/inlineMarked.ts
@@ -1,0 +1,15 @@
+// Markedライブラリを使ってMarkdownをHTMLに変換する
+
+import { Marked } from "marked";
+import aozoraRuby from "marked-aozora";
+
+const marked = new Marked({
+    async: true,
+    breaks: true,
+    gfm: true,
+    extensions: [aozoraRuby()], // Use default option
+});
+
+export const inlineMarked = async (text: string) => {
+    return marked.parseInline(text);
+};

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -1,4 +1,4 @@
-// Usage: import { getArticles, getArticleDetail } from "~/lib/microcms";
+// Usage: import { getArticles, getArticleDetail } from "@lib/microcms";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import { createClient } from "microcms-js-sdk";
 import type { ContentElement } from "./contentElements";

--- a/src/pages/article/[id].astro
+++ b/src/pages/article/[id].astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import { getArticleDetail, getArticles, type Article } from "@lib/microcms";
 import type { ContentElement } from "@lib/contentElements";
 import Headline from "@components/main/element/headline.astro";
+import Paragraph from "@components/main/element/paragraph.astro";
 
 export const getStaticPaths = (async () => {
     const response = await getArticles({ fields: ["id"] });
@@ -28,7 +29,7 @@ const response = await getArticleDetail(id, { fields: ["title", "elements"] });
                     case "headline":
                         return <Headline headline={e} />;
                     case "paragraph":
-                        return <p>{e.text}</p>;
+                        return <Paragraph paragraph={e} />;
 
                     default:
                         break;


### PR DESCRIPTION
- add✨: Install Marked and Marked-Aozora libraries for Markdown parsing
- update🍚: Change comment to import path in microcms.ts to use alias for consistency
- update🍚: Change comment from 'インラインテキスト' to 'パラグラフ' for clarity in contentElements.ts
- update📝: Fix typo in ContentParagraphElement type definition in contentElements.ts
- feat👍: Add Paragraph component to render paragraph elements in articles